### PR TITLE
CdmaCallForwardEditPreference: fix null_phone_number cannot be resolved 

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1492,4 +1492,9 @@
     <string name="exportAllcontatsFailed"> Failed to export all contacts to SIM !!!</string>
     <string name="exportAllcontatsNoContacts"> No Contacts found to export to SIM !!!</string>
     <string name="cursorError"> Cursor is not having proper data !!! </string>
+
+    <string name="CFActivate">Activate</string>
+    <string name="CFDeactivate">Deactivate</string>
+    <string name="null_phone_number">Phone number cannot be null !</string>
+    <string name="labelCFDeactAll">Deactivate All</string>
 </resources>


### PR DESCRIPTION
CdmaCallForwardEditPreference: added strings back 
Some needed strings were removed here https://github.com/Cardinal-AOSP/packages_services_Telephony/commit/0046651e10a15ff927a39ba7d924cf159840aa1e
